### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,11 +13,11 @@ I2C_EEPROM	KEYWORD1
 #######################################
 
 get	KEYWORD2
-put KEYWORD2
-getString KEYWORD2
-putString KEYWORD2
-write KEYWORD2
-read  KEYWORD2
+put	KEYWORD2
+getString	KEYWORD2
+putString	KEYWORD2
+write	KEYWORD2
+read	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords